### PR TITLE
Fix package not found error on type imports

### DIFF
--- a/packages/components/src/stories/Button.stories.tsx
+++ b/packages/components/src/stories/Button.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
-import { Story, Meta } from '@storybook/react/types-6-0';
+import type { Story, Meta } from '@storybook/react/types-6-0';
 
 import { Button, ButtonProps } from './Button';
 

--- a/packages/components/src/stories/Header.stories.tsx
+++ b/packages/components/src/stories/Header.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
-import { Story, Meta } from '@storybook/react/types-6-0';
+import type { Story, Meta } from '@storybook/react/types-6-0';
 
 import { Header, HeaderProps } from './Header';
 

--- a/packages/components/src/stories/Page.stories.tsx
+++ b/packages/components/src/stories/Page.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
-import { Story, Meta } from '@storybook/react/types-6-0';
+import type { Story, Meta } from '@storybook/react/types-6-0';
 
 import { Page, PageProps } from './Page';
 import * as HeaderStories from './Header.stories';


### PR DESCRIPTION
After running `yarn start` I'm getting the following error:
```
[snowpack] ! building dependencies...
[snowpack] Package "@storybook/react/types-6-0" not found. Have you installed it?
```

I found out that snowpack requires using `import type` when importing ts types (see https://www.snowpack.dev/reference/common-error-details#uncaught-syntaxerror%3A-the-requested-module-%E2%80%98%2F_snowpack%2Fpkg%2Fxxxxxx.js%E2%80%99-does-not-provide-an-export-named-%E2%80%98yyyyyy%E2%80%99)

So adding `import type` to the storybook imports fixed the issue